### PR TITLE
Remove `mkdir` lines in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM gradle:6-jdk11 AS builder
 
-RUN mkdir -p /app
 WORKDIR /app
 COPY . /app
 RUN gradle wrapper && ./gradlew build
@@ -9,8 +8,8 @@ FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
 
 RUN useradd -m ontology
 USER ontology
-RUN mkdir -p /home/ontology
 WORKDIR /home/ontology
+
 COPY configs/config.json index-config.json
 COPY --from=builder /app/build/layers/libs libs
 COPY --from=builder /app/build/layers/resources resources


### PR DESCRIPTION
The `mkdir` lines in the Dockerfile are not required, `WORKDIR` creates the directory [if it doesn't exist](https://docs.docker.com/engine/reference/builder/#workdir) and the `-m` parameter in `RUN useradd -m ontology` creates a home (https://linux.die.net/man/8/useradd)